### PR TITLE
Merge release v0.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,27 +70,75 @@ zenkat list pages --filter "any tags.name = daily"
 
 #### Pages
 ```
-
+title: str # filename without extensions
+filename: str
+abs_path: str
+rel_path: str
+created_at: datetime
+modified_at: datetime
+tags: list[Tag]
+out_links: list[Link] # external links are not indexed for now
+out_link_count: int
+in_links: list[Link]
+in_link_count: int
+word_count: int
 ```
 
 #### Tags
+
 ```
-
-
+name: str
+count: int
+docs: str[str] # absolute paths of source documents
 ```
 
 #### Links
+
+```
+text: str
+href: str # the exact text of the link
+href_resolved: str
+doc_abs_path: str
+type: str # wiki or regular
 ```
 
+### Formatting
+
+You can format the output of zenkat by using a format string in Python format. Note that this no longer uses `.format()` but instead uses regexps to support subfields.
+
+```
+zenkat list pages --format "[↓{in_link_count} ↑{out_link_count}] {title}, {word_count} words ({rel_path})"
+
+zenkat list links --format "{doc_abs_path} → {href_resolved}"
+```
+
+As of v0.0.10 formatting can make use of subfields of pages correctly.
+
+```
+zenkat list pages --format "{title} {rel_path} {out_links.text} {in_links.doc_abs_path}"
 ```
 
 ### Filters
 
-Currently filters use a basic 3-token structure, separated by spaces. The last argument can be multiple words long. The format of filters is:
+Currently filters use a basic token structure, separated by spaces. The last argument can be multiple words long. The format of filters is:
 
 ```
-rel_path has college stuff
-<FIELD> <OPERATION> <VALUE>
+any tags.name = writing
+[all | any] field[.subfield*] operation value
+```
+
+Subfields become lists which can be queried by using the `any` and `all` keywords. (Effectively, the `.` is a map command).
+
+```
+any tags.name = writing
+```
+
+As of v0.0.10 `dateutil` is used to parse dates, meaning most date strings will work as expected.
+
+```
+created_at < 2023-10
+created_at > Jun 2023
+created_at > September 10, 2023
 ```
 
 Operations currently supported are:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ZenKat is a tool and library to enable using a set of plaintext files, especially markdown files, as a [Zettelkasten](https://en.wikipedia.org/wiki/Zettelkasten) knowledge base.
 
-I've used a number of knowledge management tools including Obsidian, Notion, and Coda, and have found them all lacking and / or designed in a way that makes them act as a walled garden. ZenKat is an attempt to create a lightweight FOSS alternative for command-line users.
+I've used a number of knowledge management tools including Obsidian, Notion, and Coda, and have found them all lacking and / or designed in a way that makes them act as a walled garden. ZenKat is an attempt to create a lightweight FOSS alternative for command-line users. As such it aims to have few dependencies while still providing decent features.
 
 It's named this way because of my bad memory for German. I remembered ZEttelKAsTen as ZenKat (unclear where the N came from).
 
@@ -12,11 +12,13 @@ It's named this way because of my bad memory for German. I remembered ZEttelKAsT
 
 ## Recommended Setup
 
-Zenkat has no dependencies beyond the Python standard library and can be [installed from PyPi](https://pypi.org/project/zenkat/). It also installs the zenkat convenience script (renamed from zk).
+You can install directly from pip:
 
 ```
 pip install zenkat
 ```
+
+This also installs the `zenkat` convenience script.
 
 If you'd like to run directly from source you can clone the repository and use [development mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html).
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Operations currently supported are:
 <
 >=
 <=
-has (opposite of in, works on sets, strings, and dicts)
+has (opposite of in, works on sets, lists, strings, and dicts)
 ```
 
 ### Sorting

--- a/README.md
+++ b/README.md
@@ -30,56 +30,58 @@ For viewing files as formatted you can use [MD Fileserver]( https://github.com/c
 
 ## Usage
 
-ZenKat supports basic filtering, formatting, and sorting of results based on the fields it indexes. At the moment it can output pages and current tags used across pages. You can customise the output using `--format`.
+ZenKat supports basic filtering, formatting, and sorting of results based on the fields it indexes. As of version v0.0.10 it indexes documents, links, and tags and can recursively access properties. You can customise the output using `--format`.
 
 ```
-zk list --filter "tags has todo" --format "{rel_path} {tags}"
+zenkat list pages --filter "tags.name has writing" --format "{rel_path} {tags.name}"
 ```
 
 One of the most powerful features of ZenKat is the ability to calculate backlinks and resolve paths:
 ```
-zk list --format "{title} [↓{in_link_count} ↑{out_link_count}] ({rel_path})" --sort "in_link_count asc"
+zenkat list pages --sort "in_link_count asc"
 ```
 
 It can correctly operate over dates using filters.
 
 ```
-zk list --filter "created_at > Sep 25 2023 10:00AM"
+zenkat list pages --filter "created_at > Sep 25 2023"
 ```
 
 You can also combine multiple filters, which will act like an AND statement.
 
 ```
-zk list --filter "rel_path has business" --filter "rel_path has Client"
+zenkat list pages --filter "rel_path has business" --filter "rel_path has Client"
 ```
 
 You can sort by fields using straightforward ascending / descending statements. Note that you can only sort on one field at the moment.
 
 ```
-zk list --filter "rel_path has business" --sort "modified_at asc" --format "{modified_at} {filename}"
+zenkat list pages --filter "rel_path has business" --sort "modified_at asc" --format "{modified_at} {filename}"
 ```
 
 You can get a simple list of tags and then find which pages have those tags:
 
 ```
-zk tags
-zk list --filter "tags has personal"
+zenkat list tags
+zenkat list pages --filter "any tags.name = daily"
 ```
 
 ### Fields
 
+#### Pages
 ```
-title: str
-filename: str
-abs_path: str
-rel_path: str
-created_at: datetime
-modified_at: datetime
-tags: set[str]
-out_links: set[str]
-out_link_count: int
-in_links: set[str]
-in_link_count: int
+
+```
+
+#### Tags
+```
+
+
+```
+
+#### Links
+```
+
 ```
 
 ### Filters
@@ -104,7 +106,7 @@ has (opposite of in, works on sets, strings, and dicts)
 
 ### Sorting
 
-You can sort by any non-compound field using the following syntax:
+You can sort by any non-compound field using the following syntax.
 
 ```
 <FIELD> {asc / desc}

--- a/example/index.md
+++ b/example/index.md
@@ -8,7 +8,7 @@ This is an example card file which is designed to show some of the features of Z
 
 zenkat now supports [normal markdown links](notes/chapter-1) and wiki-style links like [[notes/chapter-1]]. However, it requires a correct relative path to do so.
 
-[Google](https://www.google.com)
+External links like [Google](https://www.google.com) can be used but may not be indexed.
 
 You can make a list of links:
 - [Daily 1](notes/daily_1)

--- a/example/index.md
+++ b/example/index.md
@@ -6,7 +6,7 @@ This is an example card file which is designed to show some of the features of Z
 
 ## Links
 
-zenkat now supports [normal markdown links](notes/chapter-1) and wiki-style links like [[notes/chapter-1]].
+zenkat now supports [normal markdown links](notes/chapter-1) and wiki-style links like [[notes/chapter-1]]. However, it requires a correct relative path to do so.
 
 ## Current Todos
 

--- a/example/index.md
+++ b/example/index.md
@@ -8,6 +8,8 @@ This is an example card file which is designed to show some of the features of Z
 
 zenkat now supports [normal markdown links](notes/chapter-1) and wiki-style links like [[notes/chapter-1]]. However, it requires a correct relative path to do so.
 
+[Google](https://www.google.com)
+
 You can make a list of links:
 - [Daily 1](notes/daily_1)
 - [Daily 2](notes/daily_2)

--- a/example/index.md
+++ b/example/index.md
@@ -8,6 +8,11 @@ This is an example card file which is designed to show some of the features of Z
 
 zenkat now supports [normal markdown links](notes/chapter-1) and wiki-style links like [[notes/chapter-1]]. However, it requires a correct relative path to do so.
 
+You can make a list of links:
+- [Daily 1](notes/daily_1)
+- [Daily 2](notes/daily_2)
+- [Daily 3](notes/daily_3)
+
 ## Current Todos
 
 Todos aren't treated in a special way yet, but they might be in the future.

--- a/example/index.md
+++ b/example/index.md
@@ -4,6 +4,10 @@
 
 This is an example card file which is designed to show some of the features of ZenKat (including planned future features). It can also be seen as a collection of tips for organising a plaintext Zennkasten from my own experience.
 
+## Links
+
+zenkat now supports [normal markdown links](notes/chapter-1) and wiki-style links like [[notes/chapter-1]].
+
 ## Current Todos
 
 Todos aren't treated in a special way yet, but they might be in the future.

--- a/example/notes/chapter 1.md
+++ b/example/notes/chapter 1.md
@@ -1,0 +1,34 @@
+---
+title: "Chapter 1 of awesome novel"
+author: "Frank"
+---
+
+#writing #creative-writing #novel
+
+[Return to Index](../index)
+
+This note is a helpful reference for looking at syntax of complex documents.
+
+# Chapter 1 of My Awesome Novel
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+
+## Chapter 1.1
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+
+## Chapter 1.2
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+
+### Chapter 1.2.1
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+
+#### Chapter 1.2.1.1
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+
+## Chapter 1.3
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?

--- a/example/notes/chapter-1.md
+++ b/example/notes/chapter-1.md
@@ -5,6 +5,8 @@ author: "Frank"
 
 #writing #creative-writing #novel
 
+[Return to Index](../index)
+
 This note is a helpful reference for looking at syntax of complex documents.
 
 # Chapter 1 of My Awesome Novel

--- a/example/notes/daily_1.md
+++ b/example/notes/daily_1.md
@@ -1,0 +1,5 @@
+#daily
+
+# Notes Today
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?

--- a/example/notes/daily_2.md
+++ b/example/notes/daily_2.md
@@ -1,0 +1,5 @@
+#daily
+
+# Notes Today
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?

--- a/example/notes/daily_3.md
+++ b/example/notes/daily_3.md
@@ -1,0 +1,5 @@
+#daily
+
+# Notes Today
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 [project]
 name = "zenkat"
-version = "0.0.9.2"
+version = "0.0.10"
 authors = [
   {name = "Frank Davies", email= "frank@fd93.me"}
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-dateutil==2.8.2
+six==1.16.0

--- a/src/zenkat/zenkat.py
+++ b/src/zenkat/zenkat.py
@@ -157,7 +157,7 @@ def index(path : str, exclude : list = []):
 
     # append tags to pages
     for tag_name, tag_obj in tag_names.items():
-        pages_w_tag = tag_obj.docs.union(page_paths.keys())
+        pages_w_tag = tag_obj.docs.intersection(page_paths.keys())
         for page_path in pages_w_tag:
             page_paths[page_path].tags.append(tag_obj)
     
@@ -190,8 +190,9 @@ def convert_input_to_field(data_type, input_str: str, field_name: str):
     '''
     Given a data_type, which must be a dataclass instance or class, convert the input str to be the same type as the field designated by name
     ''' 
-    
+
     fs = fields(data_type)
+
     
     columns = [f for f in fs if f.name == field_name]
     if len(columns) == 0: raise ValueError()

--- a/src/zenkat/zenkat.py
+++ b/src/zenkat/zenkat.py
@@ -240,7 +240,7 @@ def generate_filter(filter_str : str, data_type):
                 compare_to = convert_input_to_field(el, tokens[2], subfield_name)
                 # convert tokens[2] based on type of subfield
                 subfield = el.__dict__[subfield_name]
-                if el.__dict__[subfield_name] == tokens[2]:
+                if fn(el.__dict__[subfield_name], compare_to):
                     return True
             return False
         return search_iter

--- a/src/zenkat/zenkat.py
+++ b/src/zenkat/zenkat.py
@@ -176,12 +176,6 @@ def get_content(page : Page):
         content = f.read()
     return content
 
-def format_list(pages : list[Page], f_str : str):
-    outputs = []
-    for p in pages:
-        o = asdict(p)
-        outputs.append(f_str.format_map(o))
-    return outputs
 
 def convert_date_str(date_str : str):
     return dateutil.parser.parse(date_str)
@@ -216,6 +210,19 @@ def get_field_fn(obj, field_name: str):
         map_fn = lambda o: get_field_fn(o, ".".join(parts[1:]))
         field = list(map(map_fn, field))
     return field
+
+def format_list(objs : list[Any], f_str : str):
+    outputs = []
+    pattern = "{([\w.]+)}"    
+    for o in objs:
+        templates = re.findall(pattern, f_str)
+        replacements = [get_field_fn(o,t) for t in templates]
+        cur_str = f_str
+        for i, r in enumerate(replacements):
+            cur_str = re.sub(pattern, str(r), cur_str, count=1)
+        outputs.append(cur_str)
+        
+    return outputs
 
 def get_operator(op_str):
     operator_map = {

--- a/src/zenkat/zenkat.py
+++ b/src/zenkat/zenkat.py
@@ -259,6 +259,8 @@ def parse_filter(filter_str: str, data_type):
 
     operation = get_operator(tokens[1])
 
+    tokens[2] = " ".join(tokens[2:])
+
     def filter_fn(o):
         # get field values
         field = get_field_fn(o, field_specifier)

--- a/src/zenkat/zenkat.py
+++ b/src/zenkat/zenkat.py
@@ -46,6 +46,7 @@ class Page:
     out_link_count: int = 0
     in_links: list[Link] = field(default_factory=list)
     in_link_count: int = 0
+    word_count: int = 0
 
 @dataclass
 class Index:
@@ -79,6 +80,9 @@ def get_all_links(document: str):
     all_links.extend(get_regular_links(document))
     return all_links
     
+def get_word_count(document: str):
+    words = document.split()
+    return len(words)
 
 def resolve_links(links : list[Link], path : Path):
     out = []
@@ -103,7 +107,6 @@ def index(path : str, exclude : list = []):
     pages: list[Page] = []
     links_out: list[Link] = []
     tags: list[Tag] = []
-
     page_paths: dict[str, Page] = dict()
     link_dests: dict[str,list[Link]] = dict()
     tag_names: dict[str, Tag] = dict()
@@ -135,6 +138,7 @@ def index(path : str, exclude : list = []):
         cur_page.out_links = resolve_links(links, p.parent)
         links_out.extend(cur_page.out_links)
         cur_page.out_link_count = len(cur_page.out_links)
+        cur_page.word_count = get_word_count(document)
         # add to absolute path dict
         for l in cur_page.out_links:
             if l.href_resolved not in link_dests:

--- a/src/zenkat/zk.py
+++ b/src/zenkat/zk.py
@@ -44,7 +44,7 @@ def cmd_list(args):
     if args.filter != None:
         filter_strs = args.filter
 
-    filters = [zenkat.generate_filter(f, data[0]) for f in filter_strs]
+    filters = [zenkat.parse_filter(f, data[0]) for f in filter_strs]
 
     filtered = zenkat.filter_objs(data, filters)
     

--- a/src/zenkat/zk.py
+++ b/src/zenkat/zk.py
@@ -30,7 +30,7 @@ def cmd_list(args):
         f_str = "{doc_abs_path} → {href_resolved}"
         data = index.links
     elif args.corpus == "pages": 
-        f_str = "[↓{in_link_count} ↑{out_link_count}] {title} ({rel_path})"
+        f_str = "[↓{in_link_count} ↑{out_link_count}] {title}, {word_count} words ({rel_path})"
         data = index.pages
     elif args.corpus == "tags": 
         f_str = "[{count} pages] {name}"

--- a/src/zenkat/zk.py
+++ b/src/zenkat/zk.py
@@ -9,9 +9,9 @@ def get_pages(args):
     filter_strs = []
     if args.filter != None:
         filter_strs = args.filter
-    filters = [zenkat.generate_filter(f) for f in filter_strs]
+    filters = [zenkat.generate_filter(f, zenkat.Page) for f in filter_strs]
     pages = zenkat.index(args.path, exclude)
-    filtered = zenkat.filter_pages(pages, filters)
+    filtered = zenkat.filter_objs(pages, filters)
     if args.sort != None:
         filtered = zenkat.sort_from_query(filtered, args.sort)
     return filtered

--- a/src/zenkat/zk.py
+++ b/src/zenkat/zk.py
@@ -27,12 +27,13 @@ def cmd_list(args):
     index = zenkat.index(args.path)
 
     if args.corpus == "links":
-        f_str = "{doc_abs_path} -> {href_resolved}"
+        f_str = "{doc_abs_path} → {href_resolved}"
         data = index.links
     elif args.corpus == "pages": 
         f_str = "[↓{in_link_count} ↑{out_link_count}] {title} ({rel_path})"
         data = index.pages
     elif args.corpus == "tags": 
+        f_str = "[{count} pages] {name}"
         data = index.tags
     else: raise ValueError()
     


### PR DESCRIPTION
### RELEASE 0.0.10

This release focuses on enhancing the basic functionality of zenkat to make it more usable on real-world zettelkastens.

- Allow different date formats in queries
- Support regular internal / outbound links
- Make links searchable like pages
- Make tags searchable like pages
  - Change command syntax to e.g. `zenkat list pages` or `zenkat list tags`
- Add word count to pages
- Add a way to check tag / link properties in filter syntax
- Make tag / link subproperties support nesting
- Make --format support subproperties in same way as --filter
- Improve --format and --filter to use more of a spread / map operation for subproperties e.g. `list pages --filter "all tags.name = writing"`.